### PR TITLE
Add Gitea support

### DIFF
--- a/extension/options.html
+++ b/extension/options.html
@@ -54,6 +54,16 @@
         Add only the domain name(s) one per line (e.g. framagit.org)
     </p>
 
+    <label>
+        Additional Gitea instances
+    </label>
+    <textarea id="giteas" rows="6" cols="50">
+    </textarea>
+
+    <p>
+        Add only the domain name(s) one per line (e.g. try.gitea.io)
+    </p>
+
 </div>
 
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -35,6 +35,12 @@ function save_options() {
         gitlabs: gitlabs
     })
 
+    var giteas = document.getElementById('giteas').value;
+
+    browser.storage.local.set({
+        giteas: giteas
+    })
+
     var status = document.getElementById('status');
     status.textContent = 'Preferences saved.';
 
@@ -71,6 +77,11 @@ function restore_options() {
     }, function (items) {
         document.getElementById('gitlabs').value = items.gitlabs;
     });
+    browser.storage.local.get({
+        giteas: null
+    }, function (items) {
+        document.getElementById('giteas').value = items.giteas;
+    });
 }
 
 
@@ -84,4 +95,6 @@ document.getElementById('swhtoken').addEventListener('input',
 document.getElementById('ghtoken').addEventListener('input',
     save_options);
 document.getElementById('gitlabs').addEventListener('input',
+    save_options);
+document.getElementById('giteas').addEventListener('input',
     save_options);

--- a/extension/updateswh.js
+++ b/extension/updateswh.js
@@ -292,6 +292,24 @@ function updategitlabhandlers(domains){
     return
 };
 
+function updategiteahandlers(domains){
+    var domainexpr =
+	domains
+	.replace(/ /g, "") // sanitize input
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape for regexp
+	.replace(/[\n\r]/g, "|"); // turn multiple domains into alternation
+    var addrecord  =
+	{
+            pattern: RegExp("^https?:\/\/("+domainexpr+")\/[^\/]+\/[^\/]+"),
+            reject:  RegExp("^https?:\/\/("+domainexpr+")\/(users|explore)\/"),
+            type: 'Gitea instance',
+            handler: setupGiteaInstance
+	};
+    forgehandlers.push(addrecord);
+    devLog("updated Gitea instances", forgehandlers);
+    return
+};
+
 
 // Get the status of the repository by polling the results of the handler until
 // its work is completed, then show the result with the save icon and quit.
@@ -530,6 +548,10 @@ function runWithSettings() {
 	if (settings.gitlabs) {
 	    devLog("update gitlab instances");
 	    updategitlabhandlers(settings.gitlabs);
+	};
+	if (settings.giteas) {
+	    devLog("update gitea instances");
+	    updategiteahandlers(settings.giteas);
 	};
         devLog("got settings in runWithSettings", settings);
 	devLog("updateswh is running");

--- a/extension/updateswh.js
+++ b/extension/updateswh.js
@@ -277,11 +277,12 @@ var forgehandlers = [{
 function updategitlabhandlers(domains){
     var domainexpr =
 	domains
-	.replace(RegExp(" ","g"), "") // sanitize text
-	.replace(RegExp("[\n\r]","g"), "|");
+	.replace(/ /g, "") // sanitize input
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // escape for regexp
+	.replace(/[\n\r]/g, "|"); // turn multiple domains into alternation
     var addrecord  =
 	{
-            pattern: RegExp("^https?:\/\/("+domainexpr+")\/[^\/]*\/[^\/]+"),
+            pattern: RegExp("^https?:\/\/("+domainexpr+")\/[^\/]+\/[^\/]+"),
             reject:  RegExp("^https?:\/\/("+domainexpr+")\/users\/sign_in"),
             type: 'GitLab instance',
             handler: setupGitLabInstance

--- a/extension/updateswh.js
+++ b/extension/updateswh.js
@@ -203,6 +203,23 @@ function setupGitLabInstance(url, pattern, type) {
     };
 }
 
+function setupGiteaInstance(url, pattern, type) {
+    var projecturl = pattern.exec(url)[0]; // this is the url of the project
+    var forgebaseurl = new URL(projecturl).origin;
+    var userproject = new URL(projecturl).pathname.substring(1); // user+project fragment
+    var forgeapiurl = forgebaseurl + "/api/v1/repos/" + userproject;
+    devLog("Setting up Gitea instance at: " + forgebaseurl);
+    return {
+        projecturl: projecturl,
+        userproject: userproject,
+        forgeapiurl: forgeapiurl,
+        forgename: type,
+        lastupdate: (function (resp) {
+            return resp.updated_at;
+        })
+    };
+}
+
 
 // array of regex patterns to identify the project forge from the url
 // associates forge type and handling function
@@ -240,6 +257,20 @@ var forgehandlers = [{
         reject:  /^https?:\/\/gitlab\.[^.\/]+\.[^.\/]+\/users\/sign_in/,
         type: 'GitLab instance',
         handler: setupGitLabInstance
+    },
+    // hardcoded list of gitea instances
+    {
+        pattern: /^https?:\/\/(git\.rampin\.org|codeberg\.org)\/[^\/]+\/[^\/]+/,
+        reject:  /^https?:\/\/(git\.rampin\.org|codeberg\.org)\/(user|explore)\//,
+        type: 'Gitea instance',
+        handler: setupGiteaInstance
+    },
+    // heuristic: we handle gitea.*.* as a Gitea instance
+    {
+        pattern: /^https?:\/\/(gitea\.[^.\/]+\.[^.\/]+)\/[^\/]+\/[^\/]+/,
+        reject:  /^https?:\/\/(gitea\.[^.\/]+\.[^.\/]+)\/(user|explore)\//,
+        type: 'Gitea instance',
+        handler: setupGiteaInstance
     },
 ]
 


### PR DESCRIPTION
Builds on top of #6 so please review that first.

This adds support for [Gitea](https://gitea.io/en-us/), a popular open-source forge written in Go. The implementation is similar to GitLab, with some instances hardcoded and a heuristic for `gitea.<domain>`